### PR TITLE
Livestreamer and RTMP protocol handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Dopestreamer/src/META-INF/MANIFEST.MF
 
 Dopestreamer/Dopestreamer.iml
+Dopestreamer/.metadata/

--- a/Dopestreamer/src/com/dopelives/dopestreamer/Environment.java
+++ b/Dopestreamer/src/com/dopelives/dopestreamer/Environment.java
@@ -6,6 +6,7 @@ import java.io.PrintStream;
 import javafx.application.Application;
 
 import com.dopelives.dopestreamer.gui.StageManager;
+import com.dopelives.dopestreamer.shell.Console;
 import com.dopelives.dopestreamer.shell.Shell;
 import com.dopelives.dopestreamer.streams.StreamManager;
 import com.dopelives.dopestreamer.util.OutputSpy;
@@ -42,6 +43,36 @@ public class Environment {
     public static void main(final String[] args) {
         System.setOut(new PrintStream(sOutputSpy));
         System.setErr(new PrintStream(sOutputSpy));
+		
+        //Livestreamer passthrough mode (all args are passed directly to Livestreamer)
+        if (args.length > 0) {
+        	
+        	final Shell shell = Shell.getInstance();
+            String command = shell.getLivestreamerPath();
+        	
+            //concatenate arguments into one string
+			String livestreamerArgs = "";
+			for (int i=0; i<args.length; i++) {
+				livestreamerArgs += args[i] + " ";
+			}
+			
+			//strip the livestreamer protocol
+			if (livestreamerArgs.toLowerCase().startsWith("livestreamer://")) {
+				livestreamerArgs = livestreamerArgs.substring("livestreamer://".length());
+			}
+			else if (livestreamerArgs.toLowerCase().startsWith("livestreamer:")) {
+				livestreamerArgs = livestreamerArgs.substring("livestreamer:".length());
+			}
+	
+			command += " " + livestreamerArgs.trim();
+			
+			System.out.println("run: " + command);
+			
+			final Console console = shell.createConsole(command);
+			console.start();
+			
+			return;
+        }
 
         TrayManager.getInstance().show();
 

--- a/Dopestreamer/src/com/dopelives/dopestreamer/gui/StageManager.java
+++ b/Dopestreamer/src/com/dopelives/dopestreamer/gui/StageManager.java
@@ -25,7 +25,7 @@ public class StageManager extends Application {
     /** The window's width */
     public static final int WIDTH = 300;
     /** The window's height */
-    public static final int HEIGHT = 415;
+    public static final int HEIGHT = 445;
     /** The margin that JavaFX adds for some reason */
     public static final int MARGIN_CORRECTION = 10;
 

--- a/Dopestreamer/src/com/dopelives/dopestreamer/gui/controllers/Settings.java
+++ b/Dopestreamer/src/com/dopelives/dopestreamer/gui/controllers/Settings.java
@@ -29,6 +29,9 @@ import com.dopelives.dopestreamer.Environment;
 import com.dopelives.dopestreamer.TrayManager;
 import com.dopelives.dopestreamer.gui.Screen;
 import com.dopelives.dopestreamer.gui.combobox.MediaPlayerCell;
+import com.dopelives.dopestreamer.shell.Console;
+import com.dopelives.dopestreamer.shell.Shell;
+import com.dopelives.dopestreamer.shell.WindowsShell;
 import com.dopelives.dopestreamer.streams.players.MediaPlayer;
 import com.dopelives.dopestreamer.streams.players.MediaPlayerManager;
 import com.dopelives.dopestreamer.util.Pref;
@@ -45,6 +48,8 @@ public class Settings implements Initializable {
     private CheckBox notificationToggle;
     @FXML
     private CheckBox notificationDingdongToggle;
+	@FXML
+    private Button registerProtocolButton;
     @FXML
     private ComboBox<MediaPlayer> mediaPlayerSelection;
     @FXML
@@ -101,6 +106,12 @@ public class Settings implements Initializable {
 
         // Set text of player location field
         mediaPlayerLocation.setText(Pref.PLAYER_LOCATION.getString());
+        
+        final Shell shell = Shell.getInstance();
+        String results = shell.executeCommandForResult("REG QUERY HKEY_CLASSES_ROOT\\livestreamer /ve");
+        if (results.indexOf("ERROR") == -1) {
+        	registerProtocolButton.setStyle("-fx-color: lightgreen");
+        }
     }
 
     @FXML
@@ -154,6 +165,56 @@ public class Settings implements Initializable {
                 });
             }
         }, 1000);
+    }
+	
+	@FXML
+    public void onRegisterProtocol() {
+        if (!(Shell.getInstance() instanceof WindowsShell)) { return; }		//windows only :(
+
+        File dopestreamerFile = new File(Environment.class.getProtectionDomain().getCodeSource().getLocation().getPath());
+        String dopestreamerPath = dopestreamerFile.getAbsolutePath();
+        dopestreamerPath = dopestreamerPath.replace("\\", "\\\\");
+        
+        if (dopestreamerPath.toLowerCase().endsWith(".jar")) {
+        	dopestreamerPath = "java -jar " + dopestreamerPath;
+        }
+        else if (!dopestreamerFile.exists() || dopestreamerFile.isDirectory()) {
+        	System.out.println("Error: Dopestreamer path is invalid");
+        	registerProtocolButton.setStyle("-fx-color: red");
+        	return;
+        }
+        
+        //register livestreamer and rtmp-protocols
+        String[] commands = {
+        		"REG ADD HKEY_CLASSES_ROOT\\livestreamer /f /ve /t REG_SZ /d \"URL:livestreamer protocol\"",
+        		"REG ADD HKEY_CLASSES_ROOT\\livestreamer /f /v \"URL Protocol\" /t REG_SZ /d \"\"",
+        		"REG ADD HKEY_CLASSES_ROOT\\livestreamer\\Shell\\Open\\Command /f /ve /t REG_SZ /d \"" + dopestreamerPath + " \\\"%1 best\\\"\"",
+        		"REG ADD HKEY_CLASSES_ROOT\\rtmp /f /ve /t REG_SZ /d \"URL:livestreamer protocol\"",
+        		"REG ADD HKEY_CLASSES_ROOT\\rtmp /f /v \"URL Protocol\" /t REG_SZ /d \"\"",
+        		"REG ADD HKEY_CLASSES_ROOT\\rtmp\\Shell\\Open\\Command /f /ve /t REG_SZ /d \"" + dopestreamerPath + " \\\"%1 best\\\"\"",
+        };
+        
+        boolean success = true;
+        
+        //TODO: elevation prompt?
+        final Shell shell = Shell.getInstance();
+        for (int i=0; i<commands.length; i++) {
+        	String results = shell.executeCommandForResult(commands[i]);
+
+        	if (results.indexOf("ERROR") != -1) {
+        		success = false;
+        	}
+        }
+        
+        //disable button if succeeded, or paint it red if failed
+        if (success) {
+        	registerProtocolButton.setDisable(true);
+        	registerProtocolButton.setStyle("-fx-color: lightgreen");
+        }
+        else {
+        	registerProtocolButton.setStyle("-fx-color: red");
+        	System.out.println("Error: Protocol registration failed, try again with elevation.");
+        }
     }
 
     @FXML

--- a/Dopestreamer/src/com/dopelives/dopestreamer/res/layout/settings.fxml
+++ b/Dopestreamer/src/com/dopelives/dopestreamer/res/layout/settings.fxml
@@ -35,7 +35,8 @@
     <CheckBox fx:id="notificationToggle" onAction="#onNotificationToggle" text="Notifications when streams start" />
     <VBox prefHeight="10" />
     <CheckBox fx:id="notificationDingdongToggle" onAction="#onNotificationDingdongToggle" text="Tanzenkat DINGDONG notifications" />
-    
+    <VBox prefHeight="10" />
+    <Button fx:id="registerProtocolButton" onAction="#onRegisterProtocol" text="Register livestreamer+rtmp protocols" />
     
     <Label text="Media player" />
 	<ComboBox fx:id="mediaPlayerSelection" prefWidth="260" prefHeight="30" />

--- a/Dopestreamer/src/com/dopelives/dopestreamer/shell/LinuxShell.java
+++ b/Dopestreamer/src/com/dopelives/dopestreamer/shell/LinuxShell.java
@@ -55,6 +55,29 @@ public class LinuxShell extends Shell {
         // Close current process
         executeCommand("kill " + processId);
     }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getLivestreamerPath() {
+        String path = "";
+
+        // Check if there's a bundled Livestreamer installation
+        File livestreamerCheck = new File(Environment.EXE_DIR + "livestreamer");
+        if (livestreamerCheck.exists() && !livestreamerCheck.isDirectory()) {
+        	path = "\"" + Environment.EXE_DIR + "livestreamer\"";
+        } else {
+            livestreamerCheck = new File(Environment.EXE_DIR + "livestreamer");
+            if (livestreamerCheck.exists() && !livestreamerCheck.isDirectory()) {
+            	path = "\"" + Environment.EXE_DIR + "livestreamer\"";
+            } else {
+            	path = "livestreamer";
+            }
+        }
+
+        return path;
+    }
 
     /**
      * {@inheritDoc}

--- a/Dopestreamer/src/com/dopelives/dopestreamer/shell/OSXShell.java
+++ b/Dopestreamer/src/com/dopelives/dopestreamer/shell/OSXShell.java
@@ -55,6 +55,29 @@ public class OSXShell extends Shell {
         // Close current process
         executeCommand("kill " + processId);
     }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getLivestreamerPath() {
+        String path = "";
+
+        // Check if there's a bundled Livestreamer installation
+        File livestreamerCheck = new File(Environment.EXE_DIR + "livestreamer");
+        if (livestreamerCheck.exists() && !livestreamerCheck.isDirectory()) {
+        	path = "\"" + Environment.EXE_DIR + "livestreamer\"";
+        } else {
+            livestreamerCheck = new File(Environment.EXE_DIR + "livestreamer");
+            if (livestreamerCheck.exists() && !livestreamerCheck.isDirectory()) {
+            	path = "\"" + Environment.EXE_DIR + "livestreamer\"";
+            } else {
+            	path = "livestreamer";
+            }
+        }
+
+        return path;
+    }
 
     /**
      * {@inheritDoc}

--- a/Dopestreamer/src/com/dopelives/dopestreamer/shell/Shell.java
+++ b/Dopestreamer/src/com/dopelives/dopestreamer/shell/Shell.java
@@ -136,7 +136,16 @@ public abstract class Shell {
      *            The PID of the process tree root to stop
      */
     public abstract void killProcessTree(ProcessId processId);
-
+    
+    /**
+     * Finds the path to Livestreamer binaries.
+     *
+     * @return Full path to Livestreamer executable
+     */
+    public String getLivestreamerPath() {
+        return "";
+    }
+    
     /**
      * Can be overridden to append the arguments given to Livestreamer.
      *

--- a/Dopestreamer/src/com/dopelives/dopestreamer/shell/WindowsShell.java
+++ b/Dopestreamer/src/com/dopelives/dopestreamer/shell/WindowsShell.java
@@ -56,6 +56,29 @@ public class WindowsShell extends Shell {
      * {@inheritDoc}
      */
     @Override
+    public String getLivestreamerPath() {
+        String path = "";
+
+        // Check if there's a bundled Livestreamer installation
+        File livestreamerCheck = new File(Environment.EXE_DIR + "livestreamer.exe");
+        if (livestreamerCheck.exists() && !livestreamerCheck.isDirectory()) {
+        	path = "\"" + Environment.EXE_DIR + "livestreamer.exe\"";
+        } else {
+            livestreamerCheck = new File(Environment.EXE_DIR + "livestreamer");
+            if (livestreamerCheck.exists() && !livestreamerCheck.isDirectory()) {
+            	path = "\"" + Environment.EXE_DIR + "livestreamer\"";
+            } else {
+            	path = "livestreamer";
+            }
+        }
+
+        return path;
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public String getAdditionalLivestreamerArguments() {
         String additionalArguments = "";
 

--- a/Dopestreamer/src/com/dopelives/dopestreamer/streams/Stream.java
+++ b/Dopestreamer/src/com/dopelives/dopestreamer/streams/Stream.java
@@ -99,20 +99,8 @@ public class Stream {
 
         // Prepare Livestreamer command
         final Shell shell = Shell.getInstance();
-        String command;
+        String command = shell.getLivestreamerPath();
 
-        // Check if there's a bundled Livestreamer installation
-        File livestreamerCheck = new File(Environment.EXE_DIR + "livestreamer.exe");
-        if (livestreamerCheck.exists() && !livestreamerCheck.isDirectory()) {
-            command = "\"" + Environment.EXE_DIR + "livestreamer.exe\"";
-        } else {
-            livestreamerCheck = new File(Environment.EXE_DIR + "livestreamer");
-            if (livestreamerCheck.exists() && !livestreamerCheck.isDirectory()) {
-                command = "\"" + Environment.EXE_DIR + "livestreamer\"";
-            } else {
-                command = "livestreamer";
-            }
-        }
         command += " -l debug --retry-streams " + RETRY_DELAY;
 
         // Add OS specific arguments


### PR DESCRIPTION
Enables system wide handling of custom URI-protocols, making it possible to open streams from links (for example: [livestreamer://hitbox.tv/dopefish](livestreamer://hitbox.tv/dopefish) ).

Windows only, and handler registration requires elevated permissions from users (one time only).